### PR TITLE
add (non-route) permissions check if user->isGuest() 

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -17,7 +17,9 @@ namespace dmstr\web;
  * Custom user class with additional checks and implementation of a 'root' user, who
  * has all permissions (`can()` always return true)
  *
- * It additionally performs checks for route permissions. A route permission can also be assigned to a PUBLIC_ROLE
+ * It additionally performs checks for:
+ * - route permissions. A route permission can also be assigned to a PUBLIC_ROLE
+ * - if `user->isGuest() == true` it checks if (non route) Permission is assigned to a PUBLIC_ROLE
  *
  */
 class User extends \yii\web\User
@@ -53,7 +55,12 @@ class User extends \yii\web\User
                 break;
             case !empty($params['route']):
                 $return = $this->checkAccessRoute($permissionName, $params, $allowCaching);
-                \Yii::trace("Checking route permissions for '{$permissionName}', result: {$return}", __METHOD__);
+                \Yii::trace("Checking route permissions for '{$permissionName}', result: " . (int)$return, __METHOD__);
+                return $return;
+                break;
+            case \Yii::$app->user->isGuest:
+                $return = $this->canGuest($permissionName, $params, $allowCaching);
+                \Yii::trace("Check if GuestUser has permissions for '{$permissionName}', result: " . (int)$return, __METHOD__);
                 return $return;
                 break;
             default:


### PR DESCRIPTION
this patch adds permissions check if user->isGuest() to be able to set (non-route) permissions to the PUBLIC_ROLE.
use-case: set ACCESS_READ permission for one page to be able to display pages only for Guest Users

Since these checks will potentially cost performance, we should decide if it's worth the price.

Other (minor) change: cast $result to int to see `false` in trace output