### PR TITLE
Split RouteAccessControl from AccessBehaviorTrait

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -22,9 +22,12 @@ namespace dmstr\web;
  * - GUEST_ROLE:  Special Role for GuestUser. Should have PUBLIC_ROLE as child
  *
  * It additionally performs checks for:
- * - route permissions. eg. a permission `app_site` will match, `app_site_foo`
  * - if `user->isGuest() == true` it checks if permission is assigned to a GUEST_ROLE
- *
+ * - route permissions:
+ *   - e.g. a permission `app_site` will match, `app_site_foo`
+ *   - route permissions are checked if $param for User::can() has 'route' => true
+ *   - see: self::checkAccessRoute()
+ * 
  */
 class User extends \yii\web\User
 {
@@ -132,7 +135,7 @@ class User extends \yii\web\User
     /**
      * Checks route permissions.
      *
-     * Splits `permissionName` by underscore and match parts against more global rule
+     * Splits `permissionName` by underscore or `$params['routePartSeparator']` and match parts against more global rule
      * eg. a permission `app_site` will match, `app_site_foo`
      *
      * @param $permissionName
@@ -143,7 +146,8 @@ class User extends \yii\web\User
      */
     private function checkAccessRoute($permissionName, $params, $allowCaching)
     {
-        $route = explode('_', $permissionName);
+        $separator = !empty($params['routePartSeparator']) ? $params['routePartSeparator'] : '_';
+        $route = explode($separator, $permissionName);
         $routePermission = '';
         foreach ($route as $part) {
             $routePermission .= $part;
@@ -151,7 +155,7 @@ class User extends \yii\web\User
             if ($canRoute) {
                 return true;
             }
-            $routePermission .= '_';
+            $routePermission .= $separator;
         }
 
         return false;

--- a/src/filters/RouteAccessControl.php
+++ b/src/filters/RouteAccessControl.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @link http://www.diemeisterei.de/
+ * @copyright Copyright (c) 2023 diemeisterei GmbH, Stuttgart
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace dmstr\web\filters;
+
+use yii\filters\AccessControl;
+use yii\helpers\ArrayHelper;
+use yii\web\Controller;
+
+/**
+ * This is an AccessControl filter with a "hardcoded" rule, that checks access to the current route
+ * - Access can be granted to each "level" of the current route
+ * - the permission name(s) that will be checked, are the "levels" of the route with concatinated with self::routePartSeparator
+ * Example: 
+ * - route: 'user/admin/role/index'
+ * - self::routePartSeparator = '_'
+ * - checks:
+ *   - 'user'
+ *   - 'user_admin'
+ *   - 'user_admin_role'
+ *   - 'user_admin_role_index'
+ */
+class RouteAccessControl extends AccessControl
+{
+
+    public $routePartSeparator = '_';
+    public $routeCheckParams = [];
+
+    public function beforeAction($action)
+    {
+        $this->rules[] = $this->getRouteAcessControlRule();
+        return parent::beforeAction($action);
+    }
+
+    protected function getRouteAcessControlRule()
+    {
+        if ($this->owner instanceof Controller) {
+            $controller = $this->owner;
+        } else {
+            $controller = \Yii::$app->controller;
+        }
+
+        $separator = $this->routePartSeparator;
+        $ruleParams = [
+                'allow'         => true,
+                'matchCallback' => function ($rule, $action) use ($controller, $separator) {
+                    // use id including parent modules, if empty (eg. 'app') fall-back to id
+                    $moduleId = empty($controller->module->uniqueId) ? $controller->module->id : $controller->module->uniqueId;
+                    // get parts of the route to the current controller action
+                    $permParts = array_merge(explode('/', trim($moduleId,'/')), explode('/', trim($controller->id, '/')), [$action->id]);
+                    # ... and check each level of the fullName
+                    $perm = '';
+                    foreach ($permParts as $permPart) {
+                        $perm = implode($separator, array_filter([$perm, $permPart]));
+                        if ($this->user->can($perm)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                },
+            ];
+
+        return \Yii::createObject(array_merge($this->ruleConfig, $ruleParams));
+    }
+
+}

--- a/src/traits/AccessBehaviorTrait.php
+++ b/src/traits/AccessBehaviorTrait.php
@@ -14,8 +14,7 @@ namespace dmstr\web\traits;
  * @author Christopher Stebe <c.stebe@herzogkommunikation.de>
  */
 
-use yii\base\Module;
-use yii\filters\AccessControl;
+use dmstr\web\filters\RouteAccessControl;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -28,31 +27,12 @@ trait AccessBehaviorTrait
 {
     public function behaviors()
     {
-        if ($this instanceof Module) {
-            $controller = \Yii::$app->controller;
-        } else {
-            $controller = $this;
-        }
-
         return ArrayHelper::merge(
             parent::behaviors(),
             [
                 'access' => [
-                    'class' => AccessControl::className(),
-                    'rules' => [
-                        [
-                            'allow'         => true,
-                            'matchCallback' => function ($rule, $action) use ($controller) {
-                                // use id including parent modules, if empty (eg. 'app') fall-back to id
-                                $moduleId = empty($controller->module->uniqueId) ? $controller->module->id : $controller->module->uniqueId;
-                                $permission = str_replace('/','_', trim($moduleId,'/') . '_' . $controller->id . '_' . $action->id);
-                                return \Yii::$app->user->can(
-                                    $permission,
-                                    ['route' => true]
-                                );
-                            },
-                        ]
-                    ]
+                    'class' => RouteAccessControl::class,
+                    'routeCheckParams' => ['route' => true]
                 ]
             ]
         );


### PR DESCRIPTION
This PR create a new `RouteAccessControl` filter which (re)implements the logic from the prev. `AccessBehaviorTrait` rule.

The new filter can be used as "normal" behavior without the trait drawbacks.

For BC the `AccessBehaviorTrait` still exists and use the new `RouteAccessControl` filter now.

Besides the separation itself, a few small changes were made to the AccessCheck logic during refactoring:
-  the $owner of the behavior is used as controller to get the route (parts) if the $owner is an instance of `yii\web\Controller`. In all other cases, `\Yii::$app->controller` is used.
- The separator that is used for the checked permissions is a configurable property now (defaults to '_' as before)
- The `user->can()` checks for the various "levels" of the route-permission are made inside the access rule now. This means that the check can be used with any `yii\web\User` instance now, previously only with `dmstr\web\User` instances, as the actual route checks were executed there.
- The used `user` instance for the checks is taken from the `yii\filters\AccessControl::user` property, so it is configurable now.

If this PR, or rather the idea behind it, is accepted, we should be able to remove the `dmstr\web\User::checkAccessRoute()` method, as it is no longer necessary for the RouteAccess check and as it is private it cannot be used outside of class.